### PR TITLE
adds security policy, bug and enhancement templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Use this template for reporting bugs or issues.
+title: "[DATE] - Title"
+labels: bug
+---
+# Bug Report
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce this bug (as minimally and precisely as possible)**:
+
+**Anything else relevant for this bug report?**:
+
+**Environment**:
+
+- Kubernetes version (use `kubectl version`), please list client and server:
+- CSI Adapter version (provide the release tag or commit hash):
+- Provisoner name and version (provide the release tag or commit hash):
+- Cloud provider or hardware configuration:
+- OS (e.g: `cat /etc/os-release`):
+- Kernel (e.g. `uname -a`):
+- Install tools:
+- Network plugin and version (if this is a network-related bug):
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,18 @@
+---
+name: Enhancement/Feature Request
+about: Use this template to request a new feature or enhancement for the COSI CSI Adapter
+title: "[DATE] - Title"
+---
+# Enhancement
+
+**Is your feature request related to a problem?/Why is this needed**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like in detail**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request or enhancement here. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+Information about supported Kubernetes versions can be found on the
+[Kubernetes version and version skew support policy] page on the Kubernetes website.
+
+## Reporting a Vulnerability
+
+Instructions for reporting a vulnerability can be found on the
+[Kubernetes Security and Disclosure Information] page.
+
+[Kubernetes version and version skew support policy]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
+[Kubernetes Security and Disclosure Information]: https://kubernetes.io/docs/reference/issues-security/security/#report-a-vulnerability


### PR DESCRIPTION
This PR just adds two Github issue templates and the standard k8s security policy. The goal is for issues to follow a set structure, which will in turn provide guidelines for newcomers to the project.