### PR TITLE
Event recording on pod from CSI adapter

### DIFF
--- a/pkg/client/fake/node_client.go
+++ b/pkg/client/fake/node_client.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	"context"
+	"k8s.io/client-go/tools/record"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -12,35 +13,46 @@ import (
 var _ client.NodeClient = &FakeNodeClient{}
 
 type FakeNodeClient struct {
-	MockGetBAR func(ctx context.Context, barName, barNs string) (*v1alpha1.BucketAccessRequest, error)
-	MockGetBA  func(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error)
-	MockGetBR  func(ctx context.Context, brName, brNs string) (*v1alpha1.BucketRequest, error)
-	MockGetB   func(ctx context.Context, bName string) (*v1alpha1.Bucket, error)
+	MockGetBAR func(ctx context.Context, pod *v1.Pod, barName, barNs string) (*v1alpha1.BucketAccessRequest, error)
+	MockGetBA  func(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error)
+	MockGetBR  func(ctx context.Context, pod *v1.Pod, brName, brNs string) (*v1alpha1.BucketRequest, error)
+	MockGetB   func(ctx context.Context, pod *v1.Pod, bName string) (*v1alpha1.Bucket, error)
+	MockGetPod func(ctx context.Context, podName, podNs string) (*v1.Pod, error)
 
-	MockGetResources func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error)
+	MockGetResources func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error)
 
 	MockAddBAFinalizer    func(ctx context.Context, ba *v1alpha1.BucketAccess, BAFinalizer string) error
 	MockRemoveBAFinalizer func(ctx context.Context, ba *v1alpha1.BucketAccess, BAFinalizer string) error
 }
 
-func (f FakeNodeClient) GetBAR(ctx context.Context, barName, barNs string) (*v1alpha1.BucketAccessRequest, error) {
-	return f.MockGetBAR(ctx, barName, barNs)
+func (f FakeNodeClient) GetPod(ctx context.Context, podName, podNs string) (*v1.Pod, error) {
+	return f.MockGetPod(ctx, podName, podNs)
 }
 
-func (f FakeNodeClient) GetBA(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error) {
-	return f.MockGetBA(ctx, baName)
+var fRecorder = record.NewFakeRecorder(10)
+
+func (f FakeNodeClient) Recorder() record.EventRecorder {
+	return fRecorder
 }
 
-func (f FakeNodeClient) GetBR(ctx context.Context, brName, brNs string) (*v1alpha1.BucketRequest, error) {
-	return f.MockGetBR(ctx, brName, brNs)
+func (f FakeNodeClient) GetBAR(ctx context.Context, pod *v1.Pod, barName, barNs string) (*v1alpha1.BucketAccessRequest, error) {
+	return f.MockGetBAR(ctx, pod, barName, barNs)
 }
 
-func (f FakeNodeClient) GetB(ctx context.Context, bName string) (*v1alpha1.Bucket, error) {
-	return f.MockGetB(ctx, bName)
+func (f FakeNodeClient) GetBA(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error) {
+	return f.MockGetBA(ctx, pod, baName)
 }
 
-func (f FakeNodeClient) GetResources(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
-	return f.MockGetResources(ctx, barName, barNs)
+func (f FakeNodeClient) GetBR(ctx context.Context, pod *v1.Pod, brName, brNs string) (*v1alpha1.BucketRequest, error) {
+	return f.MockGetBR(ctx, pod, brName, brNs)
+}
+
+func (f FakeNodeClient) GetB(ctx context.Context, pod *v1.Pod, bName string) (*v1alpha1.Bucket, error) {
+	return f.MockGetB(ctx, pod, bName)
+}
+
+func (f FakeNodeClient) GetResources(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
+	return f.MockGetResources(ctx, barName, podName, podNs)
 }
 
 func (f FakeNodeClient) AddBAFinalizer(ctx context.Context, ba *v1alpha1.BucketAccess, BAFinalizer string) error {

--- a/pkg/client/node_client.go
+++ b/pkg/client/node_client.go
@@ -9,7 +9,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -28,24 +31,36 @@ const (
 
 var _ NodeClient = &nodeClient{}
 
+func newRecorder(kubeClient *kubernetes.Clientset, driverName, nodeID string) record.EventRecorder {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	return eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: driverName, Host: nodeID})
+}
+
 type nodeClient struct {
 	cosiClient cs.ObjectstorageV1alpha1Interface
 	kubeClient kubernetes.Interface
+	recorder   record.EventRecorder
 }
 
 type NodeClient interface {
-	GetBAR(ctx context.Context, barName, barNs string) (*v1alpha1.BucketAccessRequest, error)
-	GetBA(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error)
-	GetBR(ctx context.Context, brName, brNs string) (*v1alpha1.BucketRequest, error)
-	GetB(ctx context.Context, bName string) (*v1alpha1.Bucket, error)
+	GetBAR(ctx context.Context, pod *v1.Pod, barName, barNs string) (*v1alpha1.BucketAccessRequest, error)
+	GetBA(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error)
+	GetBR(ctx context.Context, pod *v1.Pod, brName, brNs string) (*v1alpha1.BucketRequest, error)
+	GetB(ctx context.Context, pod *v1.Pod, bName string) (*v1alpha1.Bucket, error)
+	GetPod(ctx context.Context, podName, podNs string) (*v1.Pod, error)
 
-	GetResources(ctx context.Context, barName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error)
+	GetResources(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error)
 
 	AddBAFinalizer(ctx context.Context, ba *v1alpha1.BucketAccess, BAFinalizer string) error
 	RemoveBAFinalizer(ctx context.Context, ba *v1alpha1.BucketAccess, BAFinalizer string) error
+
+	Recorder() record.EventRecorder
 }
 
-func NewClientOrDie() NodeClient {
+func NewClientOrDie(driverName, nodeId string) NodeClient {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		panic(err.Error())
@@ -56,6 +71,7 @@ func NewClientOrDie() NodeClient {
 	return &nodeClient{
 		cosiClient: client,
 		kubeClient: kube,
+		recorder:   newRecorder(kube, driverName, nodeId),
 	}
 }
 
@@ -74,56 +90,63 @@ func ParseVolumeContext(volCtx map[string]string) (barname, podname, podns strin
 	return barname, podname, podns, nil
 }
 
-func (n *nodeClient) GetBAR(ctx context.Context, barName, barNs string) (*v1alpha1.BucketAccessRequest, error) {
+func (n *nodeClient) GetBAR(ctx context.Context, pod *v1.Pod, barName, barNs string) (*v1alpha1.BucketAccessRequest, error) {
 	klog.Infof("getting bucketAccessRequest %q", fmt.Sprintf("%s/%s", barNs, barName))
 	bar, err := n.cosiClient.BucketAccessRequests(barNs).Get(ctx, barName, metav1.GetOptions{})
 	if err != nil {
 		return nil, util.LogErr(errors.Wrap(err, util.WrapErrorGetBARFailed))
 	}
-	if !bar.Status.AccessGranted {
-		return nil, util.LogErr(util.ErrorBARNoAccess)
-	}
 	// TODO: BAR.Spec.BucketRequestName can be unset if the BucketName is set
 	if len(bar.Spec.BucketRequestName) == 0 {
+		util.EmitWarningEvent(n.recorder, pod, util.BARBucketRequestNotSet)
 		return nil, util.LogErr(util.ErrorBARUnsetBR)
 	}
+	if !bar.Status.AccessGranted {
+		util.EmitWarningEvent(n.recorder, pod, util.BARAccessNotGranted)
+		return nil, util.LogErr(util.ErrorBARNoAccess)
+	}
 	if len(bar.Status.BucketAccessName) == 0 {
+		util.EmitWarningEvent(n.recorder, pod, util.BARBucketAccessNotSet)
 		return nil, util.LogErr(util.ErrorBARUnsetBA)
 	}
 	return bar, nil
 }
 
-func (n *nodeClient) GetBA(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error) {
+func (n *nodeClient) GetBA(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error) {
 	klog.Infof("getting bucketAccess %q", fmt.Sprintf("%s", baName))
 	ba, err := n.cosiClient.BucketAccesses().Get(ctx, baName, metav1.GetOptions{})
 	if err != nil {
 		return nil, util.LogErr(errors.Wrap(err, util.WrapErrorGetBAFailed))
 	}
 	if !ba.Status.AccessGranted {
+		util.EmitWarningEvent(n.recorder, pod, util.BAAccessNotGranted)
 		return nil, util.LogErr(util.ErrorBANoAccess)
 	}
 	if ba.Status.MintedSecret == nil {
+		util.EmitWarningEvent(n.recorder, pod, util.BAMintedSecretNotSet)
 		return nil, util.LogErr(util.ErrorBANoMintedSecret)
 	}
 	return ba, nil
 }
 
-func (n *nodeClient) GetBR(ctx context.Context, brName, brNs string) (*v1alpha1.BucketRequest, error) {
+func (n *nodeClient) GetBR(ctx context.Context, pod *v1.Pod, brName, brNs string) (*v1alpha1.BucketRequest, error) {
 	klog.Infof("getting bucketRequest %q", brName)
 	br, err := n.cosiClient.BucketRequests(brNs).Get(ctx, brName, metav1.GetOptions{})
 	if err != nil {
 		return nil, util.LogErr(errors.Wrap(err, util.WrapErrorGetBRFailed))
 	}
 	if !br.Status.BucketAvailable {
+		util.EmitWarningEvent(n.recorder, pod, util.BRNotAvailable)
 		return nil, util.LogErr(util.ErrorBRNotAvailable)
 	}
 	if len(br.Status.BucketName) == 0 {
+		util.EmitWarningEvent(n.recorder, pod, util.BRBucketNameNotSet)
 		return nil, util.LogErr(util.ErrorBRUnsetBucketName)
 	}
 	return br, nil
 }
 
-func (n *nodeClient) GetB(ctx context.Context, bName string) (*v1alpha1.Bucket, error) {
+func (n *nodeClient) GetB(ctx context.Context, pod *v1.Pod, bName string) (*v1alpha1.Bucket, error) {
 	klog.Infof("getting bucket %q", bName)
 	// is BucketInstanceName the correct field, or should it be BucketClass
 	bkt, err := n.cosiClient.Buckets().Get(ctx, bName, metav1.GetOptions{})
@@ -131,30 +154,41 @@ func (n *nodeClient) GetB(ctx context.Context, bName string) (*v1alpha1.Bucket, 
 		return nil, util.LogErr(errors.Wrap(err, util.WrapErrorGetBFailed))
 	}
 	if !bkt.Status.BucketAvailable {
+		util.EmitWarningEvent(n.recorder, pod, util.BNotAvailable)
 		return nil, util.LogErr(util.ErrorBNotAvailable)
 	}
 	return bkt, nil
 }
 
-func (n *nodeClient) GetResources(ctx context.Context, barName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+func (n *nodeClient) GetPod(ctx context.Context, podName, podNs string) (*v1.Pod, error) {
+	return n.kubeClient.CoreV1().Pods(podNs).Get(ctx, podName, metav1.GetOptions{})
+}
+
+func (n *nodeClient) GetResources(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 	var bar *v1alpha1.BucketAccessRequest
 
-	if bar, err = n.GetBAR(ctx, barName, podNs); err != nil {
+	if pod, err = n.GetPod(ctx, podName, podNs); err != nil {
 		return
 	}
 
-	if ba, err = n.GetBA(ctx, bar.Status.BucketAccessName); err != nil {
+	if bar, err = n.GetBAR(ctx, pod, barName, podNs); err != nil {
 		return
 	}
 
-	if bkt, err = n.GetB(ctx, ba.Spec.BucketName); err != nil {
+	if ba, err = n.GetBA(ctx, pod, bar.Status.BucketAccessName); err != nil {
+		return
+	}
+
+	if bkt, err = n.GetB(ctx, pod, ba.Spec.BucketName); err != nil {
 		return
 	}
 
 	if secret, err = n.kubeClient.CoreV1().Secrets(ba.Status.MintedSecret.Namespace).Get(ctx, ba.Status.MintedSecret.Name, metav1.GetOptions{}); err != nil {
+		util.EmitWarningEvent(n.recorder, pod, util.MintedSecretNotFound)
 		err = errors.Wrap(err, util.WrapErrorGetSecretFailed)
 		return
 	}
+	util.EmitNormalEvent(n.recorder, pod, util.AllResourcesReady)
 	return
 }
 
@@ -201,4 +235,8 @@ func (n *nodeClient) RemoveBAFinalizer(ctx context.Context, ba *v1alpha1.BucketA
 		return err
 	}
 	return nil
+}
+
+func (n *nodeClient) Recorder() record.EventRecorder {
+	return n.recorder
 }

--- a/pkg/client/node_client_test.go
+++ b/pkg/client/node_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/client-go/tools/record"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -119,11 +120,12 @@ func TestGetBAR(t *testing.T) {
 			nc := &nodeClient{
 				kubeClient: k8sfake.NewSimpleClientset(),
 				cosiClient: cosifake.NewSimpleClientset().ObjectstorageV1alpha1(),
+				recorder:   record.NewFakeRecorder(10),
 			}
 
 			tc.prepare(nc.kubeClient, nc.cosiClient)
 
-			bar, err := nc.GetBAR(ctx, tc.barName, tc.barNs)
+			bar, err := nc.GetBAR(ctx, testutils.GetPod(), tc.barName, tc.barNs)
 
 			if diff := cmp.Diff(tc.want.bar, bar); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
@@ -210,11 +212,12 @@ func TestGetBA(t *testing.T) {
 			nc := &nodeClient{
 				kubeClient: k8sfake.NewSimpleClientset(),
 				cosiClient: cosifake.NewSimpleClientset().ObjectstorageV1alpha1(),
+				recorder:   record.NewFakeRecorder(10),
 			}
 
 			tc.prepare(nc.kubeClient, nc.cosiClient)
 
-			ba, err := nc.GetBA(ctx, tc.baName)
+			ba, err := nc.GetBA(ctx, testutils.GetPod(), tc.baName)
 
 			if diff := cmp.Diff(tc.want.ba, ba); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
@@ -306,11 +309,12 @@ func TestGetBR(t *testing.T) {
 			nc := &nodeClient{
 				kubeClient: k8sfake.NewSimpleClientset(),
 				cosiClient: cosifake.NewSimpleClientset().ObjectstorageV1alpha1(),
+				recorder:   record.NewFakeRecorder(10),
 			}
 
 			tc.prepare(nc.kubeClient, nc.cosiClient)
 
-			br, err := nc.GetBR(ctx, tc.brName, tc.brNs)
+			br, err := nc.GetBR(ctx, testutils.GetPod(), tc.brName, tc.brNs)
 
 			if diff := cmp.Diff(tc.want.br, br); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
@@ -383,11 +387,12 @@ func TestGetB(t *testing.T) {
 			nc := &nodeClient{
 				kubeClient: k8sfake.NewSimpleClientset(),
 				cosiClient: cosifake.NewSimpleClientset().ObjectstorageV1alpha1(),
+				recorder:   record.NewFakeRecorder(10),
 			}
 
 			tc.prepare(nc.kubeClient, nc.cosiClient)
 
-			b, err := nc.GetB(ctx, tc.bName)
+			b, err := nc.GetB(ctx, testutils.GetPod(), tc.bName)
 
 			if diff := cmp.Diff(tc.want.b, b); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
@@ -426,6 +431,8 @@ func TestGetResources(t *testing.T) {
 					_, _ = cosi.BucketAccesses().Create(ctx, testutils.GetBA(), metav1.CreateOptions{})
 
 					_, _ = cs.CoreV1().Secrets(testutils.Namespace).Create(ctx, testutils.GetSecret(), metav1.CreateOptions{})
+
+					_, _ = cs.CoreV1().Pods(testutils.Namespace).Create(ctx, testutils.GetPod(), metav1.CreateOptions{})
 				},
 				barName: "bucketAccessRequestName",
 				barNs:   testutils.Namespace,
@@ -444,6 +451,7 @@ func TestGetResources(t *testing.T) {
 					_, _ = cosi.BucketAccesses().Create(ctx, testutils.GetBA(), metav1.CreateOptions{})
 
 					_, _ = cs.CoreV1().Secrets(testutils.Namespace).Create(ctx, testutils.GetSecret(), metav1.CreateOptions{})
+					_, _ = cs.CoreV1().Pods(testutils.Namespace).Create(ctx, testutils.GetPod(), metav1.CreateOptions{})
 				},
 				barName: "bucketAccessRequestName",
 				barNs:   testutils.Namespace,
@@ -459,6 +467,7 @@ func TestGetResources(t *testing.T) {
 					_, _ = cosi.BucketAccessRequests(testutils.Namespace).Create(ctx, testutils.GetBAR(), metav1.CreateOptions{})
 
 					_, _ = cs.CoreV1().Secrets(testutils.Namespace).Create(ctx, testutils.GetSecret(), metav1.CreateOptions{})
+					_, _ = cs.CoreV1().Pods(testutils.Namespace).Create(ctx, testutils.GetPod(), metav1.CreateOptions{})
 				},
 				barName: "bucketAccessRequestName",
 				barNs:   testutils.Namespace,
@@ -474,6 +483,7 @@ func TestGetResources(t *testing.T) {
 					_, _ = cosi.BucketAccesses().Create(ctx, testutils.GetBA(), metav1.CreateOptions{})
 
 					_, _ = cs.CoreV1().Secrets(testutils.Namespace).Create(ctx, testutils.GetSecret(), metav1.CreateOptions{})
+					_, _ = cs.CoreV1().Pods(testutils.Namespace).Create(ctx, testutils.GetPod(), metav1.CreateOptions{})
 				},
 				barName: "bucketAccessRequestName",
 				barNs:   testutils.Namespace,
@@ -489,6 +499,7 @@ func TestGetResources(t *testing.T) {
 					_, _ = cosi.Buckets().Create(ctx, testutils.GetB(), metav1.CreateOptions{})
 					_, _ = cosi.BucketAccessRequests(testutils.Namespace).Create(ctx, testutils.GetBAR(), metav1.CreateOptions{})
 					_, _ = cosi.BucketAccesses().Create(ctx, testutils.GetBA(), metav1.CreateOptions{})
+					_, _ = cs.CoreV1().Pods(testutils.Namespace).Create(ctx, testutils.GetPod(), metav1.CreateOptions{})
 				},
 				barName: "bucketAccessRequestName",
 				barNs:   testutils.Namespace,
@@ -506,11 +517,12 @@ func TestGetResources(t *testing.T) {
 			nc := &nodeClient{
 				kubeClient: k8sfake.NewSimpleClientset(),
 				cosiClient: cosifake.NewSimpleClientset().ObjectstorageV1alpha1(),
+				recorder:   record.NewFakeRecorder(10),
 			}
 
 			tc.prepare(nc.kubeClient, nc.cosiClient)
 
-			b, ba, secret, err := nc.GetResources(ctx, tc.barName, tc.barNs)
+			b, ba, secret, _, err := nc.GetResources(ctx, tc.barName, "podName", testutils.Namespace)
 
 			if diff := cmp.Diff(tc.want.b, b); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -104,14 +104,14 @@ func TestNodePublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						tempBar := testutils.GetBAR()
-						if tempBar.Namespace == barNs && tempBar.Name == barName {
+						if tempBar.Namespace == podNs && tempBar.Name == barName {
 							ba = testutils.GetBA()
 							bkt = testutils.GetB()
 							secret = testutils.GetSecret()
 						}
-						return bkt, ba, secret, nil
+						return bkt, ba, secret, testutils.GetPod(), nil
 					},
 					MockAddBAFinalizer: func(ctx context.Context, ba *v1alpha1.BucketAccess, BAFinalizer string) error {
 						return nil
@@ -158,7 +158,7 @@ func TestNodePublishVolume(t *testing.T) {
 					&fake.MockProvisionerClient{},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						bkt = testutils.GetB(
 							testutils.WithProtocol(v1alpha1.Protocol{}),
 						)
@@ -193,7 +193,7 @@ func TestNodePublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						bkt = testutils.GetB()
 						ba = testutils.GetBA()
 						secret = testutils.GetSecret()
@@ -231,7 +231,7 @@ func TestNodePublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						bkt = testutils.GetB()
 						ba = testutils.GetBA()
 						secret = testutils.GetSecret()
@@ -269,7 +269,7 @@ func TestNodePublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						bkt = testutils.GetB()
 						ba = testutils.GetBA()
 						secret = testutils.GetSecret()
@@ -310,7 +310,7 @@ func TestNodePublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						bkt = testutils.GetB()
 						ba = testutils.GetBA()
 						secret = testutils.GetSecret()
@@ -350,7 +350,7 @@ func TestNodePublishVolume(t *testing.T) {
 					}),
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						bkt = testutils.GetB()
 						ba = testutils.GetBA()
 						secret = testutils.GetSecret()
@@ -388,7 +388,7 @@ func TestNodePublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						bkt = testutils.GetB()
 						ba = testutils.GetBA()
 						secret = testutils.GetSecret()
@@ -432,7 +432,7 @@ func TestNodePublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetResources: func(ctx context.Context, barName, barNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, err error) {
+					MockGetResources: func(ctx context.Context, barName, podName, podNs string) (bkt *v1alpha1.Bucket, ba *v1alpha1.BucketAccess, secret *v1.Secret, pod *v1.Pod, err error) {
 						bkt = testutils.GetB()
 						ba = testutils.GetBA()
 						secret = testutils.GetSecret()
@@ -520,7 +520,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					}),
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetBA: func(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error) {
+					MockGetBA: func(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error) {
 						tempBa := testutils.GetBA()
 						if tempBa.Name == baName {
 							return tempBa, nil
@@ -529,6 +529,9 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					},
 					MockRemoveBAFinalizer: func(ctx context.Context, ba *v1alpha1.BucketAccess, BAFinalizer string) error {
 						return nil
+					},
+					MockGetPod: func(ctx context.Context, podName, podNs string) (*v1.Pod, error) {
+						return testutils.GetPod(), nil
 					},
 				},
 				request: &csi.NodeUnpublishVolumeRequest{
@@ -597,12 +600,15 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetBA: func(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error) {
+					MockGetBA: func(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error) {
 						tempBa := testutils.GetBA()
 						if tempBa.Name == baName {
 							return tempBa, nil
 						}
 						return nil, errBoom
+					},
+					MockGetPod: func(ctx context.Context, podName, podNs string) (*v1.Pod, error) {
+						return testutils.GetPod(), nil
 					},
 				},
 				request: &csi.NodeUnpublishVolumeRequest{
@@ -635,8 +641,11 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					}),
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetBA: func(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error) {
+					MockGetBA: func(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error) {
 						return testutils.GetBA(), nil
+					},
+					MockGetPod: func(ctx context.Context, podName, podNs string) (*v1.Pod, error) {
+						return testutils.GetPod(), nil
 					},
 				},
 				request: &csi.NodeUnpublishVolumeRequest{
@@ -667,8 +676,11 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetBA: func(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error) {
+					MockGetBA: func(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error) {
 						return testutils.GetBA(), nil
+					},
+					MockGetPod: func(ctx context.Context, podName, podNs string) (*v1.Pod, error) {
+						return testutils.GetPod(), nil
 					},
 				},
 				request: &csi.NodeUnpublishVolumeRequest{
@@ -699,11 +711,14 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					},
 				),
 				nclient: &fake.FakeNodeClient{
-					MockGetBA: func(ctx context.Context, baName string) (*v1alpha1.BucketAccess, error) {
+					MockGetBA: func(ctx context.Context, pod *v1.Pod, baName string) (*v1alpha1.BucketAccess, error) {
 						return testutils.GetBA(), nil
 					},
 					MockRemoveBAFinalizer: func(ctx context.Context, ba *v1alpha1.BucketAccess, BAFinalizer string) error {
 						return errBoom
+					},
+					MockGetPod: func(ctx context.Context, podName, podNs string) (*v1.Pod, error) {
+						return testutils.GetPod(), nil
 					},
 				},
 				request: &csi.NodeUnpublishVolumeRequest{

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	BARNotReady = "BARNotReady"
+	BANotReady  = "BANotReady"
+	BRNotReady  = "BRNotReady"
+	BNotReady   = "BNotReady"
+
+	ResourcesReady     = "ResourceReady"
+	WritingCredentials = "WritingCredentials"
+	SuccessfulPublish  = "Success"
+)
+
+var (
+	BARBucketRequestNotSet = EventResource{
+		reason:  BARNotReady,
+		message: "Bucket Access Request spec field bucketRequestName is not set",
+	}
+	BARAccessNotGranted = EventResource{
+		reason:  BARNotReady,
+		message: "Bucket Access Request has not been granted access yet",
+	}
+	BARBucketAccessNotSet = EventResource{
+		reason:  BARNotReady,
+		message: "Bucket Access Request status field bucketAccessName is not set",
+	}
+
+	BAAccessNotGranted = EventResource{
+		reason:  BANotReady,
+		message: "Bucket Access has not been granted access yet",
+	}
+	BAMintedSecretNotSet = EventResource{
+		reason:  BANotReady,
+		message: "Bucket Access does not have reference to minted secret",
+	}
+
+	BRNotAvailable = EventResource{
+		reason:  BRNotReady,
+		message: "Bucket Request is not available yet",
+	}
+	BRBucketNameNotSet = EventResource{
+		reason:  BRNotReady,
+		message: "Bucket Request status field bucketName is not set",
+	}
+
+	BNotAvailable = EventResource{
+		reason:  BNotReady,
+		message: "Bucket is not available yet",
+	}
+
+	MintedSecretNotFound = EventResource{
+		reason:  BANotReady,
+		message: "Minted credentials secret not found",
+	}
+)
+
+var (
+	AllResourcesReady = EventResource{
+		reason:  ResourcesReady,
+		message: "Bucket resources already found and ready",
+	}
+
+	CredentialsWritten = EventResource{
+		reason:  WritingCredentials,
+		message: "All connection information written to volume mount",
+	}
+
+	SuccessfullyPublishedVolume = EventResource{
+		reason:  SuccessfulPublish,
+		message: "Publish credentials completed successfully",
+	}
+
+	SuccessfullyUnpublishedVolume = EventResource{
+		reason:  SuccessfulPublish,
+		message: "Volume successfully unpublished from pod",
+	}
+)
+
+type EventResource struct {
+	reason  string
+	message string
+}
+
+func EmitWarningEvent(recorder record.EventRecorder, object runtime.Object, resource EventResource) {
+	recorder.Event(object, corev1.EventTypeWarning, resource.reason, resource.message)
+}
+
+func EmitNormalEvent(recorder record.EventRecorder, object runtime.Object, resource EventResource) {
+	recorder.Event(object, corev1.EventTypeNormal, resource.reason, resource.message)
+}

--- a/pkg/util/test/utils.go
+++ b/pkg/util/test/utils.go
@@ -11,6 +11,15 @@ const (
 	Namespace = "test"
 )
 
+func GetPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "podName",
+			Namespace: Namespace,
+		},
+	}
+}
+
 func GetBAR() *v1alpha1.BucketAccessRequest {
 	return &v1alpha1.BucketAccessRequest{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -30,6 +30,9 @@ func ParseValue(key string, volCtx map[string]string) (string, error) {
 
 // logErr should be called at the interface method scope, prior to returning errors to the gRPC client.
 func LogErr(e error) error {
+	if e == nil {
+		return nil
+	}
 	klog.Error(e)
 	return e
 }

--- a/resources/daemonset.yaml
+++ b/resources/daemonset.yaml
@@ -85,7 +85,6 @@ spec:
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
-                  apiVersion: v1
                   fieldPath: spec.nodeName
           volumeMounts:
           - mountPath: /csi
@@ -112,7 +111,6 @@ spec:
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
-                  apiVersion: v1
                   fieldPath: spec.nodeName
             - name: DATA_PATH
               value: /cosi-secret-dir


### PR DESCRIPTION
Fixes: #28 

This PR handles recording events on the pod during the mounting process for credentials/connection information.

This should not be merged in until #31 is merged.