### PR TITLE
resources: allow read access to Pods

### DIFF
--- a/resources/rbac.yaml
+++ b/resources/rbac.yaml
@@ -17,7 +17,7 @@ rules:
   resources: ["events"]
   verbs: ["list", "watch", "create", "update", "patch"]
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["pods", "secrets"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["objectstorage.k8s.io"]
   resources: ["bucketaccesses"]


### PR DESCRIPTION
The `ClusterRole` deployed with/for the driver lacks read access to
Pods, which is needed since fc868d05dd158cb1298ea113d120080c5e7293f1.

Fixes: https://github.com/kubernetes-sigs/container-object-storage-interface-csi-adapter/issues/33
See: https://github.com/kubernetes-sigs/container-object-storage-interface-csi-adapter/commit/fc868d05dd158cb1298ea113d120080c5e7293f1#diff-184694ad6baa9738a47d41dde3dfaa5f8d8ecccd555520740748c51c7d31223bR163