### PR TITLE
Update refs from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/resources/daemonset.yaml
+++ b/resources/daemonset.yaml
@@ -71,7 +71,7 @@ spec:
             type: DirectoryOrCreate
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -149,7 +149,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9898


### PR DESCRIPTION
With the [change to defaulting](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) to registry.k8s.io as our image registry and the [planned freeze in April](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/), projects within the Kubernetes orgs need to update their image references to point to the new address.

ref: https://github.com/kubernetes/k8s.io/issues/4738